### PR TITLE
Correct hashbang for the python 2 example

### DIFF
--- a/HX711_Python2.7/example.py
+++ b/HX711_Python2.7/example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 from hx711_python_2 import HX711		# import the class HX711
 import RPi.GPIO as GPIO		# import GPIO
 


### PR DESCRIPTION
This was a copy paste mistake I did in my last pull request. 

See Issue #4 