### PR TITLE
correct True False return in reset() function

### DIFF
--- a/HX711_Python3/hx711.py
+++ b/HX711_Python3/hx711.py
@@ -652,9 +652,9 @@ class HX711:
         self.power_up()
         result = self.get_raw_data_mean(6)
         if result:
-            return False
-        else:
             return True
+        else:
+            return False
 
 
 def outliers_filter(data_list):


### PR DESCRIPTION
You might prefer to return True when result returns something right ?
Otherwise, it stop at the setup.
There is still the GPIO.setmode() bug from #14 but that is out of topic for this